### PR TITLE
Add `cores_per_run` option to `boot_jaatha`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: jaatha
-Version: 3.1.1
+Version: 3.1.1.9000
 License: GPL (>= 3)
 Title: Simulation-Based Maximum Likelihood Parameter Estimation
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+jaatha 3.2.0 (in development)
+============
+
+* Adds the `cores_per_run` to `boot_jaatha` which can be set to use more than 
+  one CPU core for each replica.
+
+
+
 jaatha 3.1.1
 ============
 

--- a/R/boot_jaatha.R
+++ b/R/boot_jaatha.R
@@ -4,29 +4,53 @@
 #' function to bootstrap Jaatha estimates. Each bootstap replication requires
 #' a complete jaatha estimation on data simulated with the original parameter
 #' estimates. Therefore, bootstrapping is normally computationally demanding and
-#' should be executed on a computing cluster. The jaatha analyses are
-#' resticted to a single CPU cores, so that as many replicas as possible can 
-#' be executed in parallel using the corresponding options of 
-#' \code{\link[boot]{boot}}.
+#' should be executed on a computing cluster.
 #' 
 #' @param results The results of an \code{\link{jaatha}} analysis.
 #' @param R The number of bootstrapping replicates that are performed.
+#' @param cores_per_run The number of cores that are used for each replicate.
+#'        This corresponds to the \code{cores} option of \code{\link{jaatha}}.
+#'        Different replicates can be executed in parallel using the 
+#'        \code{parallel}, \code{ncpus} and \code{cl} options of 
+#'        \code{\link[boot]{boot}}.  The total number of CPU cores
+#'        used is \code{ncpus} * \code{cores_per_run}.
 #' @param ... Additional arguments that are passed on \code{\link[boot]{boot}}.
 #'   It is highly recommended to use its \code{parallel} and \code{ncpus} 
 #'   options to parallelize the bootstrap replicates.
 #' @return The result of \code{\link[boot]{boot}}. This object can be used to
 #'   estimate standard errors or confidence intervals of the estimates using
 #'   the functions available in package \pkg{boot}.
+#' @seealso 
+#' \code{\link[boot]{boot}}, \code{\link{jaatha}}
+#' 
+#' @examples 
+#' \dontrun{
+#' # The original Jaatha anaylsis:
+#' jaatha_result <- jaatha(model, data, cores = 4)
+#' 
+#' # Bootstrapping the results using 4 CPU cores on host1 and 2 on host2/host3:
+#' library(boot)
+#' library(snow)
+#' cl <- makeSOCKcluster(c("host1", "host1", "host2", "host3"))
+#' 
+#' jaatha_boot_results <- boot_jaatha(jaatha_result, 200, 
+#'                                    cores_per_run = 2,
+#'                                    parallel = "snow",
+#'                                    cl = cl)
+#' 
+#' stopCluster(cl)
+#' boot.ci(jaatha_boot_results, type = "norm")
+#' }
 #' 
 #' @export
-boot_jaatha <- function(results, R, ...) {
+boot_jaatha <- function(results, R, cores_per_run = 1, ...) {
   require_package("boot")
   if (R.Version()$major == 3 && R.Version()$minor < 2.2) {
     stop("This function requires at least R Version 3.2.2")
   }
   
   args <- results$args
-  args$cores <- 1
+  args$cores <- cores_per_run
   model <- args$model
   sim_func <- model$get_sim_func()
   
@@ -50,7 +74,7 @@ boot_jaatha <- function(results, R, ...) {
   }
   
   boot::boot(0, jaatha_stat, R = R, 
-             sim = "parametric", 
+             sim = "parametric",
              ran.gen = simulate_data, 
              mle = results$estimate, ...)
 }

--- a/man/boot_jaatha.Rd
+++ b/man/boot_jaatha.Rd
@@ -4,12 +4,19 @@
 \alias{boot_jaatha}
 \title{Parametric Bootstrapping of Jaatha Estimates}
 \usage{
-boot_jaatha(results, R, ...)
+boot_jaatha(results, R, cores_per_run = 1, ...)
 }
 \arguments{
 \item{results}{The results of an \code{\link{jaatha}} analysis.}
 
 \item{R}{The number of bootstrapping replicates that are performed.}
+
+\item{cores_per_run}{The number of cores that are used for each replicate.
+This corresponds to the \code{cores} option of \code{\link{jaatha}}.
+Different replicates can be executed in parallel using the 
+\code{parallel}, \code{ncpus} and \code{cl} options of 
+\code{\link[boot]{boot}}.  The total number of CPU cores
+used is \code{ncpus} * \code{cores_per_run}.}
 
 \item{...}{Additional arguments that are passed on \code{\link[boot]{boot}}.
 It is highly recommended to use its \code{parallel} and \code{ncpus} 
@@ -25,9 +32,29 @@ This function is a helper function for using the \code{\link[boot]{boot}}
 function to bootstrap Jaatha estimates. Each bootstap replication requires
 a complete jaatha estimation on data simulated with the original parameter
 estimates. Therefore, bootstrapping is normally computationally demanding and
-should be executed on a computing cluster. The jaatha analyses are
-resticted to a single CPU cores, so that as many replicas as possible can 
-be executed in parallel using the corresponding options of 
-\code{\link[boot]{boot}}.
+should be executed on a computing cluster.
+}
+\examples{
+\dontrun{
+# The original Jaatha anaylsis:
+jaatha_result <- jaatha(model, data, cores = 4)
+
+# Bootstrapping the results using 4 CPU cores on host1 and 2 on host2/host3:
+library(boot)
+library(snow)
+cl <- makeSOCKcluster(c("host1", "host1", "host2", "host3"))
+
+jaatha_boot_results <- boot_jaatha(jaatha_result, 200, 
+                                   cores_per_run = 2,
+                                   parallel = "snow",
+                                   cl = cl)
+
+stopCluster(cl)
+boot.ci(jaatha_boot_results, type = "norm")
+}
+
+}
+\seealso{
+\code{\link[boot]{boot}}, \code{\link{jaatha}}
 }
 


### PR DESCRIPTION
Adds the `cores_per_run` to `boot_jaatha` which can be set to use more than one CPU core for each bootstrap replica.