### PR TITLE
Fix one parameter models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: jaatha
-Version: 3.1.1.9005
+Version: 3.1.1.9007
 License: GPL (>= 3)
 Title: Simulation-Based Maximum Likelihood Parameter Estimation
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,11 @@ jaatha 3.2.0 (in development)
 * Now tries to continue the estimation even when a few simulations return 
   errors (#131).
 * Skips tests if `testthat` is not available (#132).
-* Adds new options `final_sim` and `zoom_in_steps` to the main jaatha `method`.
+* Adds new options `final_sim` and `zoom_in_steps` to the main jaatha `method` 
+  (#134).
+* Fixes a bug that lead to a broken assertion when jaatha was used on a model
+  with one parameter and `repetitions` was greater than one (#135). 
+  Thanks to Amaya Romero for reporting and locating this bug!.
 
 
 

--- a/R/initialization.R
+++ b/R/initialization.R
@@ -56,8 +56,10 @@ do_initial_search <- function(model, data, reps, sim, cores, sim_cache) {
   # Return the parameters for the best estimates
   best_indexes <- order(vapply(estimates, function(x) x$value, numeric(1)), 
                         decreasing = TRUE)[1:reps]
-  t(vapply(estimates[best_indexes], function(x) x$par, 
-           numeric(model$get_par_number())))
+  best_est <- vapply(estimates[best_indexes], function(x) x$par, 
+                     numeric(model$get_par_number()))
+  if (!is.matrix(best_est)) best_est <- matrix(best_est, nrow = 1)
+  t(best_est)
 }
 
 
@@ -100,7 +102,7 @@ do_zoom_in_search <- function(model, data, reps, sim, cores, sim_cache,
                               block_width, n_steps = 3) {
   "Starts with estimating parameters in the complete parameter space, an then 
    iteratively deceases the size of the block"
-  t(vapply(1:reps, function(i) {
+  best_est <- vapply(1:reps, function(i) {
     middle <- rep(.5, model$get_par_number())
     block_widths <- utils::head(seq(1, block_width, 
                                     length.out = n_steps + 1), -1)
@@ -119,5 +121,7 @@ do_zoom_in_search <- function(model, data, reps, sim, cores, sim_cache,
                          })
     }
     middle
-  }, numeric(model$get_par_number())))
+  }, numeric(model$get_par_number()))
+  if (!is.matrix(best_est)) best_est <- matrix(best_est, nrow = 1)
+  t(best_est)
 }

--- a/man/estimate_llh.Rd
+++ b/man/estimate_llh.Rd
@@ -21,7 +21,7 @@ will be estimated.}
 expectation values of the summary statistics.}
 
 \item{cores}{The number of CPU cores that will be used for the simulations.
-The relies on the \pkg{parallel} package, and consequenlty only one
+The relies on the \pkg{parallel} package, and consequently only one
 core is supported on Windows.}
 
 \item{normalized}{For internal use. Indicates whether the parameter

--- a/man/get_start_pos.Rd
+++ b/man/get_start_pos.Rd
@@ -22,7 +22,7 @@ See \code{\link{create_jaatha_data}}.}
 repetition is chosen.}
 
 \item{cores}{The number of CPU cores that will be used for the simulations.
-The relies on the \pkg{parallel} package, and consequenlty only one
+The relies on the \pkg{parallel} package, and consequently only one
 core is supported on Windows.}
 
 \item{sim_cache}{The simulation cache used in the jaatha analysis}

--- a/man/jaatha.Rd
+++ b/man/jaatha.Rd
@@ -16,7 +16,7 @@ See \code{\link{create_jaatha_model}}.}
 \item{data}{The data used for the estimation.
 See \code{\link{create_jaatha_data}}.}
 
-\item{repetitions}{The number of independend optimizations that will be
+\item{repetitions}{The number of independent optimizations that will be
 conducted. You should use a value greater than one here, to minimize
 the chance that the algorithms is stuck in a local maximum.}
 
@@ -29,7 +29,7 @@ converge.}
 is chosen. See below for a description of the different options.}
 
 \item{cores}{The number of CPU cores that will be used for the simulations.
-The relies on the \pkg{parallel} package, and consequenlty only one
+The relies on the \pkg{parallel} package, and consequently only one
 core is supported on Windows.}
 
 \item{verbose}{If \code{TRUE}, information about the optimization algorithm
@@ -48,7 +48,7 @@ the estimates of the likelihoods differ from the corrected values in the
 
 \item{final_sim}{The number of simulations conducted for calculating 
 precise likelihoods for the best estimates found in the optimization
-predure. These number of simulations is conducted for the the best
+procedure. These number of simulations is conducted for the best
 five estimates from each repetition. Using the default value is usually
 fine.}
 
@@ -78,7 +78,7 @@ Simulation based maximum likelihood estimation
   starting positions. The option \code{zoom-in} starts with a block that
   is equal to the complete parameter space, estimate parameters in there,
   and then iteratively creates a smaller block around the estimates. Finally,
-  \code{random} chooses random starting postions and
+  \code{random} chooses random starting positions and
   \code{middle} will just start all repetitions at the middle of the 
   parameter space.
 }

--- a/tests/testthat/test-initialization.R
+++ b/tests/testthat/test-initialization.R
@@ -79,6 +79,23 @@ test_that("zoom-in search works", {
 })
 
 
+test_that("the initialization supports one-parameter models", {
+  model <- create_jaatha_model(function(x) rpois(10, x),
+                               par_ranges = matrix(c(0.1, 10), 1, 2),
+                               sum_stats = list(stat_identity(), stat_sum()),
+                               test = FALSE)
+  data <- create_test_data(model)
+  sim_cache <- create_sim_cache()
+  
+  for (method in c("zoom-in", "initial-search", "random", "middle")) {
+    par <- get_start_pos(model, data, 2, 20, method, cores = 1, 
+                         sim_cache = sim_cache, block_width = 0.05)
+    expect_that(par, is_a("matrix"))
+    expect_equal(dim(par), c(2, 1))
+  }
+})
+
+
 test_that("getting the start positions works", {
   model <- create_test_model()
   data <- create_test_data(model)

--- a/tests/testthat/test-jaatha-function.R
+++ b/tests/testthat/test-jaatha-function.R
@@ -39,7 +39,7 @@ test_that("it supports a one parameter model", {
                                test = FALSE)
   
   data <- create_test_data(model)
-  results <- jaatha(model, data, repetitions = 1, sim = 10, cores = 1, 
+  results <- jaatha(model, data, repetitions = 2, sim = 10, cores = 1, 
                     max_steps = 5 * 3)
   
   expect_is(results, "list")
@@ -47,7 +47,7 @@ test_that("it supports a one parameter model", {
   expect_true(all(results$estimate > 1))
   expect_identical(results$args$model, model)
   expect_identical(results$args$data, data)
-  expect_equal(results$args$repetitions, 1)
+  expect_equal(results$args$repetitions, 2)
   expect_equal(results$args$sim, 10)
   expect_equal(results$args$cores, 1)
   expect_equal(results$args$max_steps, 15)


### PR DESCRIPTION
Currently, Jaatha throws an error in

```R
assert_that(all(dim(start_pos) == c(reps, model$get_par_number())))
```

when used on a one parameter model with more than one repetition. This PR fixes the problem.